### PR TITLE
When retryFailedRepairs, then retry txns that crashed the process

### DIFF
--- a/lib/transactions-server.js
+++ b/lib/transactions-server.js
@@ -20,7 +20,7 @@ Meteor.startup(function() {
   Transact.prototype._repairAllIncomplete = function (mode, retryFailedRepairs) {
     if (_.contains(['complete', 'rollback'], mode)) {
       var sortDirection = (mode === 'rollback') ? -1 : 1;
-	  var transactionStatesToRepair = (retryFailedRepairs) ? ['pending', 'repairFailed'] : ['pending'];
+	  var transactionStatesToRepair = (retryFailedRepairs) ? ['pending', 'repairing', 'repairFailed'] : ['pending'];
       Transactions.find({state: {$in: transactionStatesToRepair}}, {sort: {lastModified: sortDirection}}).forEach(function (transaction) {
         tx._repairIncomplete(transaction, mode); 
       });


### PR DESCRIPTION
If the txn repair attempt crashed the process, we may not get a chance to set `{ state: "repairFailed" }`